### PR TITLE
Infection report fix

### DIFF
--- a/app/controllers/TestController.php
+++ b/app/controllers/TestController.php
@@ -101,7 +101,7 @@ class TestController extends \BaseController {
 		}
 
 		// Pagination
-		$tests = $tests->paginate(Config::get('kblis.page-items'));
+		$tests = $tests->paginate(Config::get('kblis.page-items'))->appends(Input::except('_token'));
 
 		// Load the view and pass it the tests
 		return View::make('test.index')->with('testSet', $tests)->with('testStatus', $statuses)->withInput(Input::all());

--- a/app/views/layout.blade.php
+++ b/app/views/layout.blade.php
@@ -6,8 +6,8 @@
         <link rel="stylesheet" type="text/css" href="{{ URL::asset('css/ui-lightness/jquery-ui-min.css') }}" />
         <link rel="stylesheet" type="text/css" href="{{ URL::asset('css/bootstrap.min.css') }}" />
         <link rel="stylesheet" type="text/css" href="{{ URL::asset('css/bootstrap-theme.min.css') }}" />
-        <link rel="stylesheet" type="text/css" href="{{ URL::asset('css/layout.css') }}" />
         <link rel="stylesheet" type="text/css" href="{{ URL::asset('css/dataTables.bootstrap.css') }}" />
+        <link rel="stylesheet" type="text/css" href="{{ URL::asset('css/layout.css') }}" />
         <script type="text/javascript" src="{{ URL::asset('js/jquery.js') }}"></script>
         <script type="text/javascript" src="{{ URL::asset('js/jquery-ui-min.js') }}"></script>
         <script type="text/javascript" src="{{ URL::asset('js/bootstrap.min.js') }}"></script>

--- a/app/views/reports/infection/index.blade.php
+++ b/app/views/reports/infection/index.blade.php
@@ -8,25 +8,25 @@
 	</ol>
 </div>
 {{ Form::open(array('route' => array('reports.aggregate.infection'), 'class' => 'form-inline', 'role' => 'form')) }}
-<div class='container-fluid'>
+<!-- <div class='container-fluid'> -->
 	<div class="row">
-		<div class="col-sm-3 col-md-3">
+		<div class="col-md-3">
 	    	<div class="row">
-				<div class="col-sm-2 col-md-2">
+				<div class="col-md-2">
 					{{ Form::label('start', trans("messages.from")) }}
 				</div>
-				<div class="col-sm-10 col-md-10">
+				<div class="col-md-10">
 					{{ Form::text('start', isset($input['start'])?$input['start']:date('Y-m-d'), 
 				        array('class' => 'form-control standard-datepicker')) }}
 			    </div>
 	    	</div>
 	    </div>
-	    <div class="col-sm-3 col-md-3">
+	    <div class="col-md-3">
 	    	<div class="row">
-				<div class="col-sm-2 col-md-2">
+				<div class="col-md-2">
 			    	{{ Form::label('end', trans("messages.to")) }}
 			    </div>
-				<div class="col-sm-2 col-md-10">
+				<div class="col-md-10">
 				    {{ Form::text('end', isset($input['end'])?$input['end']:date('Y-m-d'), 
 				        array('class' => 'form-control standard-datepicker')) }}
 		        </div>
@@ -41,12 +41,12 @@
 	            	isset($input['test_category'])?$input['test_category']:0, array('class' => 'form-control')) }}
 	        </div>
         </div>
-	    <div class="col-sm-2 col-md-2">
+	    <div class="col-md-2">
 		    {{ Form::button("<span class='glyphicon glyphicon-filter'></span> ".trans('messages.view'), 
 		        array('class' => 'btn btn-info', 'id' => 'filter', 'type' => 'submit')) }}
 	    </div>
 	</div>
-</div>
+<!-- </div> -->
 {{ Form::close() }}
 <br />
 <div class="panel panel-primary">
@@ -70,8 +70,8 @@
 		</p>
 	</strong>
 		<div class="table-responsive">
-			<table class="table table-bordered">
-				<tbody>
+			<table class="table table-condensed report-table-border">
+				<thead>
 					<tr>
 						<th rowspan="2">{{ Lang::choice('messages.test',1) }}</th>
 						<th rowspan="2">{{ Lang::choice('messages.measure',1) }}</th>
@@ -87,6 +87,8 @@
 							<th title='{{$description}}'>{{ $ageRange }}</th>
 					    @endforeach
 					</tr>
+				</thead>
+				<tbody>
 					<?php 
 						$testRow = "";
 

--- a/app/views/test/index.blade.php
+++ b/app/views/test/index.blade.php
@@ -11,7 +11,7 @@
     @endif
 
     <div class='container-fluid'>
-        {{ Form::open(array('route' => array('test.index'), 'class'=>'form-inline')) }}
+        {{ Form::open(array('route' => array('test.index'))) }}
             <div class='row'>
                 <div class='col-md-3'>
                     <div class='col-md-2'>

--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -414,3 +414,10 @@ label, input {
     min-width: 125px;
 }
 .spacer {  margin-top: 20px; }
+
+/*Bordered-table - evade bootstrap's break on use or col & row spans*/
+table.table.report-table-border,
+table.table.report-table-border > thead > tr > th,
+table.table.report-table-border > tbody > tr > td{
+    border: 1px solid #DDDDDD;
+}


### PR DESCRIPTION
@briankip, please review these small UI fixes

1. The `Infection report` now renders well. There had been a css conflict since the table uses col & row spans with the Bootstrap css class `table-bordered`

1. Pagination and the filters on the Test Log (test.index) can now work together.