### PR TITLE
Check if test_id is null

### DIFF
--- a/app/api/SanitasInterfacer.php
+++ b/app/api/SanitasInterfacer.php
@@ -279,7 +279,9 @@ class SanitasInterfacer implements InterfacerInterface{
         $dumper = ExternalDump::firstOrNew(array('lab_no' => $labRequest->labNo));
         $dumper->lab_no = $labRequest->labNo;
         $dumper->parent_lab_no = $labRequest->parentLabNo;
-        $dumper->test_id = $testId;
+        if($dumper->test_id == null){
+            $dumper->test_id = $testId;
+        }
         $dumper->requesting_clinician = $labRequest->requestingClinician;
         $dumper->investigation = $labRequest->investigation;
         $dumper->provisional_diagnosis = '';


### PR DESCRIPTION
In a case where we receive a second labrequest with payment info and we just need to update the old one, we ovewrite the test_id thus causing mayhem and havoc all over the universe, @mapesa review.