### PR TITLE
Fixfor missing visits

### DIFF
--- a/app/database/migrations/2015_02_11_112608_remove_unique_constraint_on_patient_number.php
+++ b/app/database/migrations/2015_02_11_112608_remove_unique_constraint_on_patient_number.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveUniqueConstraintOnPatientNumber extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('patients', function(Blueprint $table)
+		{
+			//
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('patients', function(Blueprint $table)
+		{
+			//
+		});
+	}
+
+}


### PR DESCRIPTION
bug in https://github.com/ilabafrica/iBLIS/compare/fixforMissingVisits?expand=1#diff-3cb3a6815fccccc48315ee23566b70afR206 leading to in some cases the same max_patient_id's for different requests thus patient::save() throws a silent error and everything else after that is ignored.