### PR TITLE
trim interpretation to prevent error in sanitas

### DIFF
--- a/app/api/SanitasInterfacer.php
+++ b/app/api/SanitasInterfacer.php
@@ -128,7 +128,7 @@ class SanitasInterfacer implements InterfacerInterface{
         $result = $testResults->first()->result ." ". $range ." ".$unit;
 
         $jsonResponseString = sprintf('{"labNo": "%s","requestingClinician": "%s", "result": "%s", "verifiedby": "%s", "techniciancomment": "%s"}', 
-            $labNo, $tested_by, $result, $verified_by, $interpretation);
+            $labNo, $tested_by, $result, $verified_by, trim($interpretation));
         $this->sendRequest($httpCurl, urlencode($jsonResponseString), $labNo);
         
         //loop through labRequests and foreach of them get the result and put in an array


### PR DESCRIPTION
Error from sanitas

Error 500: Executing action [notify] of controller [com.fortis.sanitas.controller.BlissController] caused exception: Error parsing JSON
Servlet: grails
URI: /sanitas/grails/bliss/notify.dispatch
Exception Message: Unterminated string at character 129 of {"labNo": "759581","requestingClinician": "59", "result": "Normal ", "verifiedby": "59", "techniciancomment": "Done: 5.2 MMOL/L "} 

Caused by: Unterminated string at character 129 of {"labNo": "759581","requestingClinician": "59", "result": "Normal ", "verifiedby": "59", "techniciancomment": "Done: 5.2 MMOL/L "} 
Class: BlissController 
At Line: [68] 
Code Snippet: