### PR TITLE
removed % in TestType and trimmed test-type and measure inputs

### DIFF
--- a/app/controllers/MeasureController.php
+++ b/app/controllers/MeasureController.php
@@ -19,7 +19,7 @@ class MeasureController extends \BaseController {
         $measureIds = array();
         foreach ($measures as $data) {
             $measure = new Measure;
-            $measure->name = $data['name'];
+            $measure->name = trim($data['name']);
             $measure->measure_type_id = $data['measure_type_id'];
             $measure->unit = $data['unit'];
             $measure->description = $data['description'];
@@ -78,7 +78,7 @@ class MeasureController extends \BaseController {
         foreach ($measure as $id => $data) {
             $measureTypeId = $data['measure_type_id'];
             $measure = Measure::find($id);
-            $measure->name = $data['name'];
+            $measure->name = trim($data['name']);
             $measure->measure_type_id = $measureTypeId;
             $measure->unit = $data['unit'];
             $measure->description = $data['description'];

--- a/app/controllers/TestTypeController.php
+++ b/app/controllers/TestTypeController.php
@@ -67,7 +67,7 @@ class TestTypeController extends \BaseController {
 		} else {
 			// store 
 			$testtype = new TestType;
-			$testtype->name = Input::get('name');
+			$testtype->name = trim(Input::get('name'));
 			$testtype->description = Input::get('description');
 			$testtype->test_category_id = Input::get('test_category_id');
 			$testtype->targetTAT = Input::get('targetTAT');
@@ -155,7 +155,7 @@ class TestTypeController extends \BaseController {
 		} else {
 			// Update
 			$testtype = TestType::find($id);
-			$testtype->name = Input::get('name');
+			$testtype->name = trim(Input::get('name'));
 			$testtype->description = Input::get('description');
 			$testtype->test_category_id = Input::get('test_category_id');
 			$testtype->targetTAT = Input::get('targetTAT');

--- a/app/models/TestType.php
+++ b/app/models/TestType.php
@@ -161,8 +161,8 @@ class TestType extends Eloquent
 	{
 		try 
 		{
-			$testName = '%'.trim($testName).'%';
-			$testTypeId = TestType::where('name', 'like', $testName)->firstOrFail();
+			$testName = trim($testName);
+			$testTypeId = TestType::where('name', 'like', $testName)->orderBy('name')->firstOrFail();
 			return $testTypeId->id;
 		} catch (ModelNotFoundException $e) 
 		{


### PR DESCRIPTION
Solves issue of RF (id->301) registered as RFTS (id->148) for ordered tests.
Sanitizes new test types and measures of any white spaces.
This [script] (https://github.com/ilabafrica/BLIS-Scripts/blob/test-type-sanitizer/scripts/fieldSanitizer.sql) cleans data presently in the test types table.
@briankip review.