### PR TITLE
check if record actually exists in external dump

### DIFF
--- a/app/models/Test.php
+++ b/app/models/Test.php
@@ -114,8 +114,12 @@ class Test extends Eloquent
 		if($this->external_id == null){
 			return false;
 		}
-		else 
+		else if(ExternalDump::where('test_id', $this->id)){
+			return false;
+		}
+		else{ 
 			return true;
+		}
 	}
 
 	/**


### PR DESCRIPTION
1. Checks results against critical values defined for parameters in Chemistry and Hematology sections.
2. Critical values noted are highlighted in red.
3. A note is appended to the interpretation comment box to alert the clinician about the critical values.